### PR TITLE
Updated the latest stable version of Zookeeper (v3.4.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM wurstmeister/base
 
 MAINTAINER Wurstmeister
 
-ENV ZOOKEEPER_VERSION 3.4.9
+ENV ZOOKEEPER_VERSION 3.4.10
 
 #Download Zookeeper
 RUN wget -q http://mirror.vorboss.net/apache/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz && \

--- a/start-zk.sh
+++ b/start-zk.sh
@@ -1,4 +1,4 @@
 sed -i -r 's|#(log4j.appender.ROLLINGFILE.MaxBackupIndex.*)|\1|g' $ZK_HOME/conf/log4j.properties
 sed -i -r 's|#autopurge|autopurge|g' $ZK_HOME/conf/zoo.cfg
 
-/opt/zookeeper-3.4.9/bin/zkServer.sh start-foreground
+/opt/zookeeper-3.4.10/bin/zkServer.sh start-foreground


### PR DESCRIPTION
According to [this](http://apache.mirrors.pair.com/zookeeper/stable/) v3.4.10 is the latest stable version of Zookeeper