### PR TITLE
Fix non-existing version repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,20 @@ gpg --verify zookeeper-${ZOOKEEPER_VERSION}.tar.gz.asc
 #Install
 RUN tar -xzf zookeeper-${ZOOKEEPER_VERSION}.tar.gz -C /opt
 
+#Move to non-versioned dir
+RUN mv /opt/zookeeper-${ZOOKEEPER_VERSION} /opt/zookeeper
+
 #Configure
-RUN mv /opt/zookeeper-${ZOOKEEPER_VERSION}/conf/zoo_sample.cfg /opt/zookeeper-${ZOOKEEPER_VERSION}/conf/zoo.cfg
+RUN mv /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
-ENV ZK_HOME /opt/zookeeper-${ZOOKEEPER_VERSION}
+ENV ZK_HOME /opt/zookeeper
 RUN sed  -i "s|/tmp/zookeeper|$ZK_HOME/data|g" $ZK_HOME/conf/zoo.cfg; mkdir $ZK_HOME/data
 
 ADD start-zk.sh /usr/bin/start-zk.sh 
 EXPOSE 2181 2888 3888
 
-WORKDIR /opt/zookeeper-${ZOOKEEPER_VERSION}
-VOLUME ["/opt/zookeeper-${ZOOKEEPER_VERSION}/conf", "/opt/zookeeper-${ZOOKEEPER_VERSION}/data"]
+WORKDIR /opt/zookeeper
+VOLUME ["/opt/zookeeper/conf", "/opt/zookeeper/data"]
 
 CMD /usr/sbin/sshd && bash /usr/bin/start-zk.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@ FROM wurstmeister/base
 
 MAINTAINER Wurstmeister
 
-ENV ZOOKEEPER_VERSION 3.4.13
+ENV ZOOKEEPER_VERSION 3.4.14
 
 #Download Zookeeper
 RUN wget -q http://mirror.vorboss.net/apache/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz && \
 wget -q https://www.apache.org/dist/zookeeper/KEYS && \
 wget -q https://www.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz.asc && \
-wget -q https://www.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz.md5
+wget -q https://www.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz.sha512
 
 #Verify download
-RUN md5sum -c zookeeper-${ZOOKEEPER_VERSION}.tar.gz.md5 && \
+RUN sha512sum -c zookeeper-${ZOOKEEPER_VERSION}.tar.gz.sha512 && \
 gpg --import KEYS && \
 gpg --verify zookeeper-${ZOOKEEPER_VERSION}.tar.gz.asc
 

--- a/start-zk.sh
+++ b/start-zk.sh
@@ -1,4 +1,4 @@
 sed -i -r 's|#(log4j.appender.ROLLINGFILE.MaxBackupIndex.*)|\1|g' $ZK_HOME/conf/log4j.properties
 sed -i -r 's|#autopurge|autopurge|g' $ZK_HOME/conf/zoo.cfg
 
-/opt/zookeeper-3.4.13/bin/zkServer.sh start-foreground
+/opt/zookeeper-3.4.14/bin/zkServer.sh start-foreground

--- a/start-zk.sh
+++ b/start-zk.sh
@@ -1,4 +1,4 @@
 sed -i -r 's|#(log4j.appender.ROLLINGFILE.MaxBackupIndex.*)|\1|g' $ZK_HOME/conf/log4j.properties
 sed -i -r 's|#autopurge|autopurge|g' $ZK_HOME/conf/zoo.cfg
 
-/opt/zookeeper-3.4.14/bin/zkServer.sh start-foreground
+/opt/zookeeper/bin/zkServer.sh start-foreground


### PR DESCRIPTION
Fix for version "3.4.13" not existing any more in the Apache and Vorbos repositories.

The current version available in those repositories is version "3.4.14".